### PR TITLE
Add the kinto permission get_perm_keys inheritance methods.

### DIFF
--- a/kinto/permission.py
+++ b/kinto/permission.py
@@ -1,0 +1,84 @@
+# List of permissions that gives us this permission
+PERMISSIONS_INHERITANCE = {
+    'bucket:write': {
+        'bucket': ['write']
+    },
+    'bucket:read': {
+        'bucket': ['write', 'read']
+    },
+    'groups:create': {
+        'bucket': ['write', 'groups:create']
+    },
+    'collections:create': {
+        'bucket': ['write', 'collections:create']
+    },
+    'group:write': {
+        'bucket': ['write'],
+        'group': ['write']
+    },
+    'group:read': {
+        'bucket': ['write', 'read'],
+        'group': ['write', 'read']
+    },
+    'collection:write': {
+        'bucket': ['write'],
+        'collection': ['write'],
+    },
+    'collection:read': {
+        'bucket': ['write', 'read'],
+        'collection': ['write', 'read'],
+    },
+    'records:create': {
+        'bucket': ['write'],
+        'collection': ['write', 'records:create']
+    },
+    'record:write': {
+        'bucket': ['write'],
+        'collection': ['write'],
+        'record': ['write']
+    },
+    'record:read': {
+        'bucket': ['write', 'read'],
+        'collection': ['write', 'read'],
+        'record': ['write', 'read']
+    }
+}
+
+
+def get_object_type(object_id):
+    """Return the type of an object from its id."""
+    if 'records' in object_id:
+        obj_type = 'record'
+    elif 'collections' in object_id:
+        obj_type = 'collection'
+    elif 'buckets' in object_id:
+        obj_type = 'bucket'
+    else:
+        raise ValueError('`%s` key is an invalid object id.' % object_id)
+    return obj_type
+
+
+def build_perm_set_id(obj_type, perm, obj_parts):
+    PARTS_LENGTH = {
+        'bucket': 3,
+        'collection': 5,
+        'record': 7
+    }
+    return 'permission:%s:%s' % (
+        '/'.join(obj_parts[:PARTS_LENGTH[obj_type]]),
+        perm
+    )
+
+
+def get_perm_keys(object_id, permission):
+    obj_parts = object_id.split('/')
+    obj_type = get_object_type(object_id)
+
+    permission_type = '%s:%s' % (obj_type, permission)
+    keys = set([])
+
+    for perm_obj_type, permissions in \
+            PERMISSIONS_INHERITANCE[permission_type].items():
+        for other_perm in permissions:
+            keys.add(build_perm_set_id(perm_obj_type, other_perm, obj_parts))
+    return keys

--- a/kinto/permission.py
+++ b/kinto/permission.py
@@ -6,10 +6,10 @@ PERMISSIONS_INHERITANCE = {
     'bucket:read': {
         'bucket': ['write', 'read']
     },
-    'groups:create': {
+    'bucket:groups:create': {
         'bucket': ['write', 'groups:create']
     },
-    'collections:create': {
+    'bucket:collections:create': {
         'bucket': ['write', 'collections:create']
     },
     'group:write': {
@@ -28,7 +28,7 @@ PERMISSIONS_INHERITANCE = {
         'bucket': ['write', 'read'],
         'collection': ['write', 'read'],
     },
-    'records:create': {
+    'collection:records:create': {
         'bucket': ['write'],
         'collection': ['write', 'records:create']
     },
@@ -51,6 +51,8 @@ def get_object_type(object_id):
         obj_type = 'record'
     elif 'collections' in object_id:
         obj_type = 'collection'
+    elif 'groups' in object_id:
+        obj_type = 'group'
     elif 'buckets' in object_id:
         obj_type = 'bucket'
     else:
@@ -62,12 +64,17 @@ def build_perm_set_id(obj_type, perm, obj_parts):
     PARTS_LENGTH = {
         'bucket': 3,
         'collection': 5,
+        'group': 5,
         'record': 7
     }
-    return 'permission:%s:%s' % (
-        '/'.join(obj_parts[:PARTS_LENGTH[obj_type]]),
-        perm
-    )
+    if obj_type not in PARTS_LENGTH:
+        raise ValueError('Invalid object type: %s' % obj_type)
+
+    if PARTS_LENGTH[obj_type] > len(obj_parts):
+        raise ValueError('You cannot build children keys from its parent key.'
+                         'Trying to build type "%s" from object key "%s".' % (
+                             obj_type, '/'.join(obj_parts)))
+    return ('/'.join(obj_parts[:PARTS_LENGTH[obj_type]]), perm)
 
 
 def get_perm_keys(object_id, permission):

--- a/kinto/tests/test_permission.py
+++ b/kinto/tests/test_permission.py
@@ -1,0 +1,143 @@
+from kinto import permission
+
+from .support import unittest
+
+
+class PermissionTest(unittest.TestCase):
+    record_id = '/buckets/blog/collections/articles/records/article1'
+    collection_id = '/buckets/blog/collections/articles'
+    group_id = '/buckets/blog/groups/moderators'
+    bucket_id = '/buckets/blog'
+    invalid_id = 'invalid object id'
+
+    def test_get_object_type_return_right_type_for_key(self):
+        self.assertEqual(permission.get_object_type(self.record_id), 'record')
+        self.assertEqual(permission.get_object_type(self.collection_id),
+                         'collection')
+        self.assertEqual(permission.get_object_type(self.bucket_id), 'bucket')
+        self.assertEqual(permission.get_object_type(self.group_id), 'group')
+        self.assertRaises(ValueError, permission.get_object_type,
+                          self.invalid_id)
+
+    def test_build_perm_set_id_can_construct_parents_set_ids(self):
+        obj_parts = self.record_id.split('/')
+        # Can build record_id from obj_parts
+        self.assertEqual(permission.build_perm_set_id('record', 'write',
+                                                      obj_parts),
+                         (self.record_id, 'write'))
+
+        # Can build collection_id from obj_parts
+        self.assertEqual(permission.build_perm_set_id('collection',
+                                                      'records:create',
+                                                      obj_parts),
+                         (self.collection_id, 'records:create'))
+
+        # Can build bucket_id from obj_parts
+        self.assertEqual(permission.build_perm_set_id('bucket',
+                                                      'groups:create',
+                                                      obj_parts),
+                         (self.bucket_id, 'groups:create'))
+
+        # Can build group_id from group obj_parts
+        obj_parts = self.group_id.split('/')
+        self.assertEqual(permission.build_perm_set_id('group',
+                                                      'read',
+                                                      obj_parts),
+                         (self.group_id, 'read'))
+
+        # Can build bucket_id from group obj_parts
+        obj_parts = self.group_id.split('/')
+        self.assertEqual(permission.build_perm_set_id('bucket',
+                                                      'write',
+                                                      obj_parts),
+                         (self.bucket_id, 'write'))
+
+    def test_build_perm_set_id_fail_construct_children_set_ids(self):
+        obj_parts = self.bucket_id.split('/')
+        # Cannot build record_id from bucket obj_parts
+        self.assertRaises(ValueError,
+                          permission.build_perm_set_id,
+                          'record', 'write', obj_parts)
+
+        # Cannot build collection_id from obj_parts
+        self.assertRaises(ValueError,
+                          permission.build_perm_set_id,
+                          'collection', 'write', obj_parts)
+
+        # Cannot build bucket_id from empty obj_parts
+        self.assertRaises(ValueError,
+                          permission.build_perm_set_id,
+                          'collection', 'write', [])
+
+    def test_build_perm_set_id_fail_on_wrong_type(self):
+        obj_parts = self.record_id.split('/')
+        self.assertRaises(ValueError,
+                          permission.build_perm_set_id,
+                          'schema', 'write', obj_parts)
+
+    def test_get_perm_keys_for_bucket_permission(self):
+        # write
+        self.assertEquals(permission.get_perm_keys(self.bucket_id, 'write'),
+                          set([(self.bucket_id, 'write')]))
+        # read
+        self.assertEquals(permission.get_perm_keys(self.bucket_id, 'read'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'read')]))
+        # groups:create
+        self.assertEquals(permission.get_perm_keys(self.bucket_id,
+                                                   'groups:create'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'groups:create')]))
+
+        # collections:create
+        self.assertEquals(permission.get_perm_keys(self.bucket_id,
+                                                   'collections:create'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'collections:create')]))
+
+    def test_get_perm_keys_for_group_permission(self):
+        # write
+        self.assertEquals(permission.get_perm_keys(self.group_id, 'write'),
+                          set([(self.bucket_id, 'write'),
+                               (self.group_id, 'write')]))
+        # read
+        self.assertEquals(permission.get_perm_keys(self.group_id, 'read'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'read'),
+                               (self.group_id, 'write'),
+                               (self.group_id, 'read')]))
+
+    def test_get_perm_keys_for_collection_permission(self):
+        # write
+        self.assertEquals(permission.get_perm_keys(self.collection_id,
+                                                   'write'),
+                          set([(self.bucket_id, 'write'),
+                               (self.collection_id, 'write')]))
+        # read
+        self.assertEquals(permission.get_perm_keys(self.collection_id, 'read'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'read'),
+                               (self.collection_id, 'write'),
+                               (self.collection_id, 'read')]))
+        # records:create
+        self.assertEquals(permission.get_perm_keys(self.collection_id,
+                                                   'records:create'),
+                          set([(self.bucket_id, 'write'),
+                               (self.collection_id, 'write'),
+                               (self.collection_id, 'records:create')]))
+
+    def test_get_perm_keys_for_record_permission(self):
+        # write
+        self.assertEquals(permission.get_perm_keys(self.record_id,
+                                                   'write'),
+                          set([(self.bucket_id, 'write'),
+                               (self.collection_id, 'write'),
+                               (self.record_id, 'write')]))
+        # read
+        self.assertEquals(permission.get_perm_keys(self.record_id, 'read'),
+                          set([(self.bucket_id, 'write'),
+                               (self.bucket_id, 'read'),
+                               (self.collection_id, 'write'),
+                               (self.collection_id, 'read'),
+                               (self.record_id, 'write'),
+                               (self.record_id, 'read')]))


### PR DESCRIPTION
Based on mozilla-services/cliquet#280

- [x] Write the ``get_perm_keys`` method for the cliquet permission backend
- [x] Write some unit tests about cliquet permissions
