### PR TITLE
Groups are not plugged to principal

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_SETTINGS = {
     'cliquet.bucket_create_principals': 'system.Authenticated',
     'multiauth.authorization_policy': (
-        'kinto.authorization.AuthorizationPolicy')
+        'kinto.authorization.AuthorizationPolicy'),
+    'multiauth.groupfinder': (
+        'kinto.authorization.groupfinder')
 }
 
 

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -135,10 +135,7 @@ def build_permissions_set(object_uri, unbound_permission,
 
 # XXX: May need caching
 def groupfinder(userid, request):
-    authn_type = getattr(request, 'authn_type', None)
-    if authn_type is None:
-        return []
-
+    authn_type = request.authn_type
     prefixed_userid = '%s:%s' % (authn_type.lower(), userid)
     return request.registry.permission.user_principals(prefixed_userid)
 

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -133,6 +133,16 @@ def build_permissions_set(object_uri, unbound_permission,
     return granters
 
 
+# XXX: May need caching
+def groupfinder(userid, request):
+    authn_type = getattr(request, 'authn_type', None)
+    if authn_type is None:
+        return []
+
+    prefixed_userid = '%s:%s' % (authn_type.lower(), userid)
+    return request.registry.permission.user_principals(prefixed_userid)
+
+
 @implementer(IAuthorizationPolicy)
 class AuthorizationPolicy(CliquetAuthorization):
     def get_bound_permissions(self, *args, **kwargs):

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -58,6 +58,20 @@ class GroupViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_recreate_group_after_deletion_works(self):
+        group = MINIMALIST_GROUP.copy()
+        self.app.put_json('/buckets/beers/groups/moderator',
+                          group,
+                          headers=self.headers,
+                          status=201)
+        self.app.delete('/buckets/beers/groups/moderator',
+                        headers=self.headers,
+                        status=200)
+        self.app.put_json('/buckets/beers/groups/moderator',
+                          group,
+                          headers=self.headers,
+                          status=200)
+
 
 class GroupManagementTest(BaseWebTest, unittest.TestCase):
 

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -58,7 +58,7 @@ class GroupViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
-    def test_recreate_group_after_deletion_works(self):
+    def test_recreate_group_after_deletion_returns_a_200(self):
         group = MINIMALIST_GROUP.copy()
         self.app.put_json('/buckets/beers/groups/moderator',
                           group,

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -64,7 +64,11 @@ class Group(resource.ProtectedResource):
         if old is None:
             existing_record_members = set([])
         else:
-            existing_record_members = set(old['members'])
+            try:
+                existing_record_members = set(old['members'])
+            except KeyError:
+                # This occurs when there is a deleted version
+                existing_record_members = set([])
         new_record_members = set(new['members'])
         new_members = new_record_members - existing_record_members
         removed_members = existing_record_members - new_record_members

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -67,7 +67,6 @@ class Group(resource.ProtectedResource):
             try:
                 existing_record_members = set(old['members'])
             except KeyError:
-                # This occurs when there is a deleted version
                 existing_record_members = set([])
         new_record_members = set(new['members'])
         new_members = new_record_members - existing_record_members

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -64,10 +64,7 @@ class Group(resource.ProtectedResource):
         if old is None:
             existing_record_members = set([])
         else:
-            try:
-                existing_record_members = set(old['members'])
-            except KeyError:
-                existing_record_members = set([])
+            existing_record_members = set(old.get('members', []))
         new_record_members = set(new['members'])
         new_members = new_record_members - existing_record_members
         removed_members = existing_record_members - new_record_members


### PR DESCRIPTION
If you create a group and add people to it, then they cannot access records with the group as a permission principal.