### PR TITLE
use pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ migrate: install
 	$(VENV)/bin/cliquet --ini $(SERVER_CONFIG) migrate
 
 tests-once: install-dev
-	$(VENV)/bin/nosetests -s --with-mocha-reporter --with-coverage --cover-min-percentage=100 --cover-package=kinto
+	$(VENV)/bin/py.test --cov-report term-missing --cov kinto
 
 tests:
 	tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,9 @@
 WebTest
-nose
-nose-cov
-nose-mocha-reporter
 mock
 Sphinx
 sphinx_rtd_theme
 requests
-coverage
-unittest2
 https://github.com/mozilla-services/cliquet/archive/master.zip
+pytest
+pytest-cov
+pytest-sugar

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py34,flake8
 [testenv]
 commands =
     python --version
-    nosetests --with-coverage --cover-package=kinto kinto {posargs}
+    py.test --cov-report term-missing --cov kinto {posargs}
 deps = -rdev-requirements.txt
 install_command = pip install --pre {opts} {packages}
 


### PR DESCRIPTION
Caveats:
- it's not using the nose-mocha-reporter (I guess it could be adapted to pytest though, below is a screenshot using pytest-sugar)
- there's no `cover-min-percentage` option that I know of for pytest-cov

![screen shot 2015-06-26 at 11 23 27](https://cloud.githubusercontent.com/assets/167767/8384541/94861626-1bf6-11e5-85d5-2c0ac49a80ad.png)
