### PR TITLE
Personal bucket ~

### DIFF
--- a/docs/api/collections.rst
+++ b/docs/api/collections.rst
@@ -11,10 +11,17 @@ A collection is a mapping with the following attribute:
 
 .. note::
 
-    By default users have a bucket that is used for their own data.
-    Application can use this default bucket with the ``default`` shortcut.
-    ie: ``/buckets/default/collections/contacts`` will be the current
-    user contacts.
+    By default users are assigned to a bucket that is used for their
+    personal data.
+
+	Application can use this default bucket with the ``default``
+    shortcut: ie ``/buckets/default/collections/contacts`` will be
+    the current user contacts.
+
+    Internally the user default bucket is assigned to an id that can
+    later be used to share data from a user personnal bucket.
+
+    Collection on a the default bucket are created silently on first access.
 
 
 Creating a collection

--- a/docs/api/collections.rst
+++ b/docs/api/collections.rst
@@ -14,7 +14,7 @@ A collection is a mapping with the following attribute:
     By default users are assigned to a bucket that is used for their
     personal data.
 
-	Application can use this default bucket with the ``default``
+    Application can use this default bucket with the ``default``
     shortcut: ie ``/buckets/default/collections/contacts`` will be
     the current user contacts.
 

--- a/docs/api/collections.rst
+++ b/docs/api/collections.rst
@@ -9,12 +9,12 @@ A collection is a mapping with the following attribute:
 
 * ``permissions``: (*optional*) the :term:`ACLs <ACL>` for the collection object
 
-.. .. note::
+.. note::
 
-..     By default users have a bucket that is used for their own data.
-..     Application can use this default bucket with the ``default`` shortcut.
-..     ie: ``/buckets/default/collections/contacts`` will be the current
-..     user contacts. See #71 for more discussion.
+    By default users have a bucket that is used for their own data.
+    Application can use this default bucket with the ``default`` shortcut.
+    ie: ``/buckets/default/collections/contacts`` will be the current
+    user contacts.
 
 
 Creating a collection

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -37,5 +37,8 @@ def main(global_config, **settings):
     if not flush_enabled:
         kwargs['ignore'] = 'kinto.views.flush'
 
+    # Redirect default to the right endpoint
+    config.add_route('default_bucket', '/buckets/default{subpath:.*}')
+
     config.scan("kinto.views", **kwargs)
     return config.make_wsgi_app()

--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -46,11 +46,9 @@ class BaseWebTest(object):
         settings.update(**DEFAULT_SETTINGS)
         settings['cliquet.cache_backend'] = 'cliquet.cache.memory'
         settings['cliquet.storage_backend'] = 'cliquet.storage.memory'
-        settings['cliquet.permission_backend'] = 'cliquet.permission.redis'
+        settings['cliquet.permission_backend'] = 'cliquet.permission.memory'
         settings['cliquet.project_name'] = 'cloud storage'
         settings['cliquet.project_docs'] = 'https://kinto.rtfd.org/'
-        settings['multiauth.authorization_policy'] = (
-            'kinto.authorization.AuthorizationPolicy')
         settings['cliquet.userid_hmac_secret'] = "this is not a secret"
 
         if additional_settings is not None:

--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -17,8 +17,8 @@ MINIMALIST_COLLECTION = {'data': dict()}
 MINIMALIST_GROUP = {'data': dict(members=['fxa:user'])}
 MINIMALIST_RECORD = {'data': dict(name="Hulled Barley",
                                   type="Whole Grain")}
-USER_PRINCIPAL = 'basicauth:8a931a10fc88ab2f6d1cc02a07d3a81b5d4768f' \
-                 '6f13e85c5d8d4180419acb1b4'
+USER_PRINCIPAL = 'basicauth:aaedca130273574dd2bd6c3acad57f3545b662a974fa4320' \
+                 '236f25fe474676d6'
 
 
 class BaseWebTest(object):
@@ -51,6 +51,7 @@ class BaseWebTest(object):
         settings['cliquet.project_docs'] = 'https://kinto.rtfd.org/'
         settings['multiauth.authorization_policy'] = (
             'kinto.tests.support.AllowAuthorizationPolicy')
+        settings['cliquet.userid_hmac_secret'] = "azerty"
 
         if additional_settings is not None:
             settings.update(additional_settings)

--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -4,9 +4,9 @@ except ImportError:
     import unittest  # NOQA
 
 import webtest
-from cliquet import utils
 from pyramid.security import IAuthorizationPolicy
 from zope.interface import implementer
+from cliquet import utils
 from cliquet.tests import support as cliquet_support
 from kinto import main as testapp
 from kinto import DEFAULT_SETTINGS
@@ -17,8 +17,8 @@ MINIMALIST_COLLECTION = {'data': dict()}
 MINIMALIST_GROUP = {'data': dict(members=['fxa:user'])}
 MINIMALIST_RECORD = {'data': dict(name="Hulled Barley",
                                   type="Whole Grain")}
-USER_PRINCIPAL = 'basicauth:aaedca130273574dd2bd6c3acad57f3545b662a974fa4320' \
-                 '236f25fe474676d6'
+USER_PRINCIPAL = 'basicauth:3a0c56d278def4113f38d0cfff6db1b06b84fcc4384ee890' \
+                 'cf7bbaa772317e10'
 
 
 class BaseWebTest(object):
@@ -46,12 +46,12 @@ class BaseWebTest(object):
         settings.update(**DEFAULT_SETTINGS)
         settings['cliquet.cache_backend'] = 'cliquet.cache.memory'
         settings['cliquet.storage_backend'] = 'cliquet.storage.memory'
-        settings['cliquet.permission_backend'] = 'cliquet.permission.memory'
+        settings['cliquet.permission_backend'] = 'cliquet.permission.redis'
         settings['cliquet.project_name'] = 'cloud storage'
         settings['cliquet.project_docs'] = 'https://kinto.rtfd.org/'
         settings['multiauth.authorization_policy'] = (
-            'kinto.tests.support.AllowAuthorizationPolicy')
-        settings['cliquet.userid_hmac_secret'] = "azerty"
+            'kinto.authorization.AuthorizationPolicy')
+        settings['cliquet.userid_hmac_secret'] = "this is not a secret"
 
         if additional_settings is not None:
             settings.update(additional_settings)
@@ -79,9 +79,8 @@ class BaseWebTest(object):
 @implementer(IAuthorizationPolicy)
 class AllowAuthorizationPolicy(object):
     def permits(self, context, principals, permission):
-        if USER_PRINCIPAL in principals:
-            return True
-        return False
+        # Cliquet default authz policy uses prefixed_userid.
+        return USER_PRINCIPAL in ([context.prefixed_userid] + principals)
 
     def principals_allowed_by_permission(self, context, permission):
         raise NotImplementedError()  # PRAGMA NOCOVER

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -1,0 +1,33 @@
+from .support import (BaseWebTest, unittest, get_user_headers,
+                      MINIMALIST_BUCKET, MINIMALIST_RECORD)
+
+
+class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
+
+    bucket_url = '/buckets/default'
+    collection_url = '/buckets/default/collections/tasks'
+
+    def setUp(self):
+        super(DefaultBucketViewTest, self).setUp()
+
+    def test_default_bucket_exists_and_has_user_id(self):
+        bucket = self.app.get(self.bucket_url, headers=self.headers)
+
+        expected_bucket = MINIMALIST_BUCKET.copy()
+        expected_bucket['data']['id'] = self.principal
+        expected_bucket['data']['last_modified'] = self.storage \
+            .collection_timestamp(self.principal, None)
+        expected_bucket['permissions'] = {'write': [self.principal]}
+
+        self.assertDictEqual(bucket.json, expected_bucket)
+
+    def test_default_bucket_collections_are_automatically_created(self):
+        self.app.get(self.collection_url, headers=self.headers, status=200)
+
+    def test_adding_a_task_for_bob_doesnt_add_it_for_alice(self):
+        record = MINIMALIST_RECORD.copy()
+        resp = self.app.post_json(self.collection_url + '/records',
+                                  record, headers=get_user_headers('bob'))
+        record_id = self.collection_url + '/records/' + resp.json['data']['id']
+        resp = self.app.get(record_id, record,
+                            headers=get_user_headers('alice'), status=404)

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -43,3 +43,11 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
             uuid.UUID(bucket_id)
         except ValueError:
             self.fail('bucket_id: %s is not a valid UUID.' % bucket_id)
+
+    def test_second_call_on_default_bucket_doesnt_raise_a_412(self):
+        self.app.get(self.bucket_url, headers=self.headers)
+        self.app.get(self.bucket_url, headers=self.headers)
+
+    def test_second_call_on_default_bucket_collection_doesnt_raise_a_412(self):
+        self.app.get(self.collection_url, headers=self.headers)
+        self.app.get(self.collection_url, headers=self.headers)

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -32,3 +32,8 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         record_id = self.collection_url + '/records/' + resp.json['data']['id']
         resp = self.app.get(record_id, headers=get_user_headers('alice'),
                             status=404)
+
+    def test_unauthenticated_bucket_access_raises_json_401(self):
+        resp = self.app.get(self.bucket_url, status=401)
+        self.assertEquals(resp.json['message'],
+                          'Please authenticate yourself to use this endpoint.')

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -1,3 +1,4 @@
+import uuid
 from .support import (BaseWebTest, unittest, get_user_headers,
                       MINIMALIST_RECORD)
 
@@ -8,9 +9,6 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
 
     bucket_url = '/buckets/default'
     collection_url = '/buckets/default/collections/tasks'
-
-    def setUp(self):
-        super(DefaultBucketViewTest, self).setUp()
 
     def test_default_bucket_exists_and_has_user_id(self):
         bucket = self.app.get(self.bucket_url, headers=self.headers)
@@ -37,3 +35,11 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get(self.bucket_url, status=401)
         self.assertEquals(resp.json['message'],
                           'Please authenticate yourself to use this endpoint.')
+
+    def test_bucket_id_is_an_uuid(self):
+        bucket = self.app.get(self.bucket_url, headers=self.headers)
+        bucket_id = bucket.json['data']['id']
+        try:
+            uuid.UUID(bucket_id)
+        except ValueError:
+            self.fail('bucket_id: %s is not a valid UUID.' % bucket_id)

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -17,7 +17,7 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         result = bucket.json
         settings = self.app.app.registry.settings
         hmac_secret = settings['cliquet.userid_hmac_secret']
-        bucket_id = hmac_digest(hmac_secret, self.principal)
+        bucket_id = hmac_digest(hmac_secret, self.principal)[:32]
 
         self.assertEqual(result['data']['id'], bucket_id)
         self.assertEqual(result['permissions']['write'], [self.principal])

--- a/kinto/tests/test_views_flush.py
+++ b/kinto/tests/test_views_flush.py
@@ -17,8 +17,8 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
 
         self.alice_headers = self.headers.copy()
         self.alice_headers.update(**get_user_headers('alice'))
-        alice_principal = ('basicauth:a020953dabc9094455e81dfbffd74089fb1f9'
-                           'aa521e525066bd074cfca68dc6c')
+        alice_principal = ('basicauth:8df4b22019cc89d0bb679bc51373a9da56a'
+                           '7ae9978c52fbe684510c3d257c855')
         bucket['permissions'] = {'write': [alice_principal]}
 
         # Create shared bucket.

--- a/kinto/tests/test_views_flush.py
+++ b/kinto/tests/test_views_flush.py
@@ -17,8 +17,8 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
 
         self.alice_headers = self.headers.copy()
         self.alice_headers.update(**get_user_headers('alice'))
-        alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16812'
-                           'e3c64ff7ae053fe3542e2ca1570')
+        alice_principal = ('basicauth:a020953dabc9094455e81dfbffd74089fb1f9'
+                           'aa521e525066bd074cfca68dc6c')
         bucket['permissions'] = {'write': [alice_principal]}
 
         # Create shared bucket.

--- a/kinto/tests/test_views_permissions.py
+++ b/kinto/tests/test_views_permissions.py
@@ -9,12 +9,12 @@ class PermissionsTest(BaseWebTest, unittest.TestCase):
         super(PermissionsTest, self).__init__(*args, **kwargs)
         self.alice_headers = self.headers.copy()
         self.alice_headers.update(**get_user_headers('alice'))
-        self.alice_principal = ('basicauth:a020953dabc9094455e81dfbffd74089'
-                                'fb1f9aa521e525066bd074cfca68dc6c')
+        self.alice_principal = ('basicauth:8df4b22019cc89d0bb679bc51373a9da56a'
+                                '7ae9978c52fbe684510c3d257c855')
         self.bob_headers = self.headers.copy()
         self.bob_headers.update(**get_user_headers('bob'))
-        self.bob_principal = ('basicauth:f2de102efae98126a410b32683e42407a3'
-                              'f23fccb5fba063cc2c74f5477eb701')
+        self.bob_principal = ('basicauth:21364d1282b58b3af15a0d619d03122a318be'
+                              'e30c1a5a2d09c3b958e5f7fb71a')
 
 
 class BucketPermissionsTest(PermissionsTest):

--- a/kinto/tests/test_views_permissions.py
+++ b/kinto/tests/test_views_permissions.py
@@ -9,12 +9,12 @@ class PermissionsTest(BaseWebTest, unittest.TestCase):
         super(PermissionsTest, self).__init__(*args, **kwargs)
         self.alice_headers = self.headers.copy()
         self.alice_headers.update(**get_user_headers('alice'))
-        self.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155'
-                                'e16812e3c64ff7ae053fe3542e2ca1570')
+        self.alice_principal = ('basicauth:a020953dabc9094455e81dfbffd74089'
+                                'fb1f9aa521e525066bd074cfca68dc6c')
         self.bob_headers = self.headers.copy()
         self.bob_headers.update(**get_user_headers('bob'))
-        self.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec73'
-                              '794bb075154c74a0d4311e74ca8b6')
+        self.bob_principal = ('basicauth:f2de102efae98126a410b32683e42407a3'
+                              'f23fccb5fba063cc2c74f5477eb701')
 
 
 class BucketPermissionsTest(PermissionsTest):

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -21,8 +21,9 @@ def default_bucket(request):
     path = request.path.replace('default', bucket_id)
 
     # Make sure bucket exists
-    if request.method.lower() != 'put' or \
-       not request.path.endswith('buckets/default'):
+    is_bucket_put = (request.method.lower() == 'put' and
+                     request.path.endswith('buckets/default'))
+    if not is_bucket_put:
         subrequest = build_request(request, {
             'method': 'PUT',
             'path': '/buckets/%s' % bucket_id,
@@ -39,8 +40,9 @@ def default_bucket(request):
     subpath = request.matchdict['subpath']
     if subpath.startswith('/collections/'):
         collection_id = subpath.split('/')[2]
-        if request.method.lower() != 'put' or \
-           not request.path.endswith(collection_id):
+        is_collection_put = (request.method.lower() == 'put' and
+                             request.path.endswith(collection_id))
+        if not is_collection_put:
             subrequest = build_request(request, {
                 'method': 'PUT',
                 'path': '/buckets/%s/collections/%s' % (
@@ -51,7 +53,7 @@ def default_bucket(request):
             try:
                 request.invoke_subrequest(subrequest)
             except HTTPPreconditionFailed:
-                # The bucket already existed
+                # The collection already existed
                 pass
 
     subrequest = build_request(request, {

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -17,7 +17,7 @@ def default_bucket(request):
 
     settings = request.registry.settings
     hmac_secret = settings['cliquet.userid_hmac_secret']
-    bucket_id = hmac_digest(hmac_secret, request.prefixed_userid)
+    bucket_id = hmac_digest(hmac_secret, request.prefixed_userid)[:32]
     path = request.path.replace('default', bucket_id)
 
     # Make sure bucket exists

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -33,7 +33,7 @@ def default_bucket(request):
         try:
             request.invoke_subrequest(subrequest)
         except HTTPPreconditionFailed:
-            # The bucket already existed
+            # The bucket already exists
             pass
 
     # Make sure the collection exists
@@ -53,7 +53,7 @@ def default_bucket(request):
             try:
                 request.invoke_subrequest(subrequest)
             except HTTPPreconditionFailed:
-                # The collection already existed
+                # The collection already exists
                 pass
 
     subrequest = build_request(request, {

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -11,12 +11,12 @@ from kinto.views import NameGenerator
 
 @view_config(route_name='default_bucket', permission=NO_PERMISSION_REQUIRED)
 def default_bucket(request):
-    if (not hasattr(request, 'prefixed_userid') or
-            request.prefixed_userid is None):
+    if getattr(request, 'prefixed_userid', None) is None:
         raise HTTPForbidden  # Pass through the forbidden_view_config
 
     settings = request.registry.settings
     hmac_secret = settings['cliquet.userid_hmac_secret']
+    # Build the user unguessable bucket_id UUID from its user_id
     bucket_id = hmac_digest(hmac_secret, request.prefixed_userid)[:32]
     path = request.path.replace('default', bucket_id)
 

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -18,7 +18,7 @@ def create_bucket(request, bucket_id):
             'method': 'PUT',
             'path': '/buckets/%s' % bucket_id,
             'body': {"data": {}},
-            'headers': {'If-None-Match': '*'}
+            'headers': {'If-None-Match': '*'.encode('utf-8')}
         })
 
         try:
@@ -40,7 +40,7 @@ def create_collection(request, bucket_id):
                 'path': '/buckets/%s/collections/%s' % (
                     bucket_id, collection_id),
                 'body': {"data": {}},
-                'headers': {'If-None-Match': '*'}
+                'headers': {'If-None-Match': '*'.encode('utf-8')}
             })
             try:
                 request.invoke_subrequest(subrequest)


### PR DESCRIPTION
Related #70 

In the original plan, we had imagined a special bucket named ``~``, that redirects to an implicitly created bucket whose name is the user id.

We shall implement it !

See https://github.com/mozilla-services/kinto/blame/master/docs/api/collections.rst#L15