### PR TITLE
Fix default settings URL and project name

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -17,6 +17,8 @@ DEFAULT_SETTINGS = {
     'cliquet.cache_backend': 'cliquet.cache.memory',
     'cliquet.permission_backend': 'cliquet.permission.memory',
     'cliquet.storage_backend': 'cliquet.storage.memory',
+    'cliquet.project_name': 'Cloud Storage',
+    'cliquet.project_docs': 'https://kinto.readthedocs.org/',
     'cliquet.bucket_create_principals': 'system.Authenticated',
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),

--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -47,8 +47,6 @@ class BaseWebTest(object):
         settings['cliquet.cache_backend'] = 'cliquet.cache.memory'
         settings['cliquet.storage_backend'] = 'cliquet.storage.memory'
         settings['cliquet.permission_backend'] = 'cliquet.permission.memory'
-        settings['cliquet.project_name'] = 'cloud storage'
-        settings['cliquet.project_docs'] = 'https://kinto.rtfd.org/'
         settings['cliquet.userid_hmac_secret'] = "this is not a secret"
 
         if additional_settings is not None:

--- a/kinto/tests/test_views_hello.py
+++ b/kinto/tests/test_views_hello.py
@@ -9,6 +9,6 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         self.assertEqual(response.json['version'], VERSION)
         self.assertEqual(response.json['url'], 'http://localhost/v1/')
-        self.assertEqual(response.json['hello'], 'cloud storage')
+        self.assertEqual(response.json['hello'], 'Cloud Storage')
         self.assertEqual(response.json['documentation'],
-                         'https://kinto.rtfd.org/')
+                         'https://kinto.readthedocs.org/')

--- a/loadtests/server.ini
+++ b/loadtests/server.ini
@@ -2,7 +2,7 @@
 use = egg:kinto
 
 cliquet.project_name = kinto
-cliquet.project_docs = https://kinto.rtfd.org/
+cliquet.project_docs = https://kinto.readthedocs.org/
 cliquet.http_host = localhost:8888
 cliquet.http_scheme = http
 cliquet.basic_auth_enabled = true


### PR DESCRIPTION
Actually, this code https://github.com/mozilla-services/kinto/blob/cab991c928dcca17510a5c7a2762d1b64c192526/kinto/__init__.py#L16-L25 is overridding what is in the file.

It should be used as Kinto default settings and override cliquet default settings but should be overriddable by the configuration file.