### PR TITLE
Fix docs syntax/structure, add a TOC to fix RTD template

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,7 +1,7 @@
 .. _api-endpoints:
 
-The HTP APIs
-############
+The HTTP APIs
+#############
 
 .. toctree::
    :maxdepth: 2

--- a/docs/api/records.rst
+++ b/docs/api/records.rst
@@ -10,7 +10,7 @@ Sending a record
 ================
 
 .. http:post:: /buckets/(bucket_id)/collections/(collection_id)/records
-and its id will be assigned automatically
+
     **Requires authentication**
 
     Stores a record in the collection, and its id will be assigned automatically.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,8 +3,9 @@
 Configuration
 #############
 
-For an exhaustive list of *Cliquet* settings, see `cliquet settings documentation
-<http://cliquet.readthedocs.org/en/latest/configuration.html>`_.
+For an exhaustive list of *Cliquet* settings, see `cliquet settings
+documentation
+<http://cliquet.readthedocs.org/en/latest/reference/configuration.html>`_.
 
 .. _run-production:
 
@@ -17,11 +18,12 @@ Recommended settings
 Most default setting values in the application code base are suitable
 for production.
 
-Once `PostgreSQL is installed <postgresql-install>`_, the settings about
+Once :ref:`PostgreSQL is installed <postgresql-install>`, the settings about
 backends as shown in :file:`config/kinto.ini` can be uncommented in order
 to use *PostgreSQL*.
 
-Also, the set of settings mentionned below might deserve some review or adjustments:
+Also, the set of settings mentionned below might deserve some review or
+adjustments:
 
 .. code-block :: ini
 
@@ -34,7 +36,7 @@ Also, the set of settings mentionned below might deserve some review or adjustme
     cliquet.permission_pool_maxconn = 50
     fxa-oauth.cache_ttl_seconds = 3600
 
-:note:
+.. note::
 
     For an exhaustive list of available settings and their default values,
     refer to `the source code <https://github.com/mozilla-services/cliquet/blob/2.2.0/cliquet/__init__.py#L26-L78>`_.
@@ -135,11 +137,11 @@ with the `cliquet` command-line tool:
 
     $ cliquet --ini production.ini migrate
 
-:note:
+.. note::
 
     Alternatively the SQL initialization files can be found in the
-    *Cliquet* source code (``cliquet/cache/postgresql/schemal.sql`` and
-    ``cliquet/storage/postgresql/schemal.sql``).
+    *Cliquet* source code (``cliquet/cache/postgresql/schema.sql`` and
+    ``cliquet/storage/postgresql/schema.sql``).
 
 
 Running with uWsgi

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,12 +5,12 @@ Contribution guidelines
 
 Thank you for considering to contribute to *Kinto*!
 
-:note:
+.. note::
 
     No contribution is too small; please submit as many fixes for typos and
     grammar bloopers as you can!
 
-:note:
+.. note::
 
     Open a pull-request even if your contribution is not ready yet! It can
     be discussed and improved collaboratively!

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -112,7 +112,8 @@ Deploy a PostgreSQL cluster:
 * one or more replication followers («*slaves*»).
 * A load balancer, that routes queries to take advantage of the cluster (pgPool)
 
-Writes are sent to the master, and reads are sent to the master and slaves that up-to-date.
+Writes are sent to the master, and reads are sent to the master and slaves that
+are up-to-date.
 
 Vertical scaling:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Using the HTTP API
 ==================
 
 Interaction with a *Kinto* instance happens at some point using HTTP calls.
-Find all you need to know via le links below:
+Find all you need to know via the links below:
 
 - Buckets: :ref:`Working with buckets <buckets>`
 - Collections : :ref:`Handling collections <collections>` |
@@ -46,3 +46,25 @@ Community
 =========
 
 - How to contribute: :ref:`Guidelines <contributing>`
+
+Table of content
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   installation
+   tutorial
+   configuration
+   deployment
+   permissions
+   api/index
+   contributing
+   changelog
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -40,17 +40,17 @@ Authentication
 By default, Kinto relies on Firefox Account OAuth2 Bearer tokens to authenticate
 users.
 
-See `cliquet documentation <http://cliquet.readthedocs.org/en/latest/configuration.html#authentication>`_
+See `cliquet documentation <http://cliquet.readthedocs.org/en/latest/reference/configuration.html#authentication>`_
 to configure authentication options.
 
 
 Run in production
 =================
 
-*Kinto* is a usual python application.
+*Kinto* is a standard python application.
 
 Recommended settings for production are listed :ref:`in a dedicated section
-<run-production>`, and another gives some :ref:`insights about deployment strategies.
+<run-production>`, and another gives some :ref:`insights about deployment strategies
 <deployment>`.
 
 *PostgreSQL* is the recommended backend for production, see instructions below

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,15 +13,14 @@ particulary relevant as a storage backend:
 Sync user data between devices
 ==============================
 
-Let's say that we want to do a TodoMVC backend that will sync user
-tasks between her devices.
-
+Let's say that we want to do a `TodoMVC <http://todomvc.com/>`_ backend that
+will sync user tasks between the devices.
 
 In order to separate data between each user, we will use the default
 *personal bucket*.
 
-Unlike other buckets, the collections in the ``default`` bucket are created
-implicitly.
+Unlike other buckets, the :ref:`collections <collections>` in the ``default``
+:ref:`bucket <buckets>` are created implicitly.
 
 Let us start with a really simple data model:
 
@@ -34,7 +33,7 @@ And post a sample record in the ``tasks`` collection:
 
     $ echo '{"data": {"description": "Write a tutorial explaining Kinto", "status": "todo"}}' | \
         http POST https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records \
-             --auth 'user:password'
+             -v --auth 'user:password'
 
     POST /v1/buckets/default/collections/tasks/records HTTP/1.1
     Accept: application/json
@@ -82,7 +81,7 @@ Let us fetch our new collection of tasks:
 .. code-block:: http
 
     $ http GET https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records \
-           --auth 'user:password'
+           -v --auth 'user:password'
     GET /v1/buckets/default/collections/tasks/records HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
@@ -114,6 +113,10 @@ Let us fetch our new collection of tasks:
         ]
     }
 
+
+Keep a note of the ``ETag`` and of the ``last_modified`` values returned (here
+respectively ``"1434641474977"`` and ``"1434641515332"``), we'll need them for
+a later example.
 
 We can obviously also update one of our tasks, using its ``id``:
 
@@ -175,7 +178,7 @@ obtained while fetching the collection, or the value of the ``last_modified``
 data field you had for this record.
 
 Let's try to modify the record using an obsolete value of ``ETag`` (obtained
-while we fetched the collection):
+while we fetched the collection earlier, which we asked you to keep note of):
 
 .. code-block:: http
 
@@ -452,8 +455,8 @@ By default, the creator is the only administrator (see ``write`` permission).
 
 You will now have to define permissions to introduce collaboration.
 
-In our case, we want people to be able create and share tasks, so
-we will create a collection ``tasks`` with the ``record:create`` permission for
+In our case, we want people to be able to create and share tasks, so
+we will create a ``tasks`` collection with the ``record:create`` permission for
 authenticated users (i.e. ``system.Authenticated``):
 
 .. code-block:: http
@@ -674,7 +677,7 @@ the collection to allow authenticated users to list the whole list.
     private and each user obtains a list containing only the records where she
     has read access.
 
-    **This is on top of our priorities!**
+    **This is our top priority!**
 
 
 Working with groups
@@ -868,7 +871,8 @@ In this tutorial, you have seen some of the concepts exposed by *Kinto*:
 - Creating groups, collections and records;
 - Modifying objects permissions, for users and groups;
 
-More details about permissions, HTTP API headers and status codes.
+More details about :ref:`permissions <permissions>`, :ref:`HTTP API headers and
+status codes <api-endpoints>`.
 
 .. note::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -668,7 +668,7 @@ Here we share individual records, and nobody (except its creator) can obtain the
 collection records. For example, a ``read`` permission could be added on
 the collection to allow authenticated users to list the whole list.
 
-.. notes::
+.. note::
 
     Currently, *Kinto* does not support the use-case where the whole collection is
     private and each user obtains a list containing only the records where she
@@ -870,7 +870,7 @@ In this tutorial, you have seen some of the concepts exposed by *Kinto*:
 
 More details about permissions, HTTP API headers and status codes.
 
-.. notes::
+.. note::
 
     We plan to improve our documentation and make sure it is as easy as
     possible to get started with *Kinto*.


### PR DESCRIPTION
Some small fixes to the syntax and structure of some of the docs.

Regarding the "add a TOC to fix ReadTheDocs template": https://read-the-docs.readthedocs.org/en/latest/theme.html#how-the-table-of-contents-builds
Adding the TOC will make it display correctly in the left menu, and also add the "prev/next" buttons at the bottom of each pages. Much easier to navigate the docs!

There's also a second commit for improvements to the tutorial, and small fixes. I could provide this in another PR if needed. Please take note that I wasn't able to run the full tutorial, because of issues I had following along (see the issues #113 and #115 for example), so I may be missing some things.