### PR TITLE
500 when trying to GET /buckets

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,6 +42,16 @@ adjustments:
     refer to `the source code <https://github.com/mozilla-services/cliquet/blob/2.2.0/cliquet/__init__.py#L26-L78>`_.
 
 
+By default, nobody can read buckets list. You can change that using:
+
+.. code-block :: ini
+
+    cliquet.bucket_read_principals = system.Authenticated
+
+Beware that if you do so, everyone will be able to list bucket
+information (including user's personal buckets).
+
+
 Monitoring
 ----------
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -20,7 +20,6 @@ DEFAULT_SETTINGS = {
     'cliquet.project_name': 'Cloud Storage',
     'cliquet.project_docs': 'https://kinto.readthedocs.org/',
     'cliquet.bucket_create_principals': 'system.Authenticated',
-    'cliquet.bucket_read_principals': 'system.Authenticated',
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),
     'multiauth.groupfinder': (

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -20,6 +20,7 @@ DEFAULT_SETTINGS = {
     'cliquet.project_name': 'Cloud Storage',
     'cliquet.project_docs': 'https://kinto.readthedocs.org/',
     'cliquet.bucket_create_principals': 'system.Authenticated',
+    'cliquet.bucket_read_principals': 'system.Authenticated',
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),
     'multiauth.groupfinder': (

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -4,6 +4,7 @@ import logging
 import cliquet
 from pyramid.config import Configurator
 from pyramid.settings import asbool
+from pyramid.security import Authenticated
 from cliquet.authorization import RouteFactory
 
 # Module version, as defined in PEP-0396.
@@ -19,7 +20,7 @@ DEFAULT_SETTINGS = {
     'cliquet.storage_backend': 'cliquet.storage.memory',
     'cliquet.project_name': 'Cloud Storage',
     'cliquet.project_docs': 'https://kinto.readthedocs.org/',
-    'cliquet.bucket_create_principals': 'system.Authenticated',
+    'cliquet.bucket_create_principals': Authenticated,
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),
     'multiauth.groupfinder': (

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -122,6 +122,8 @@ def build_permissions_set(object_uri, unbound_permission,
 
     obj_type = get_object_type(object_uri)
 
+    # Unknown object type, does not map the INHERITANCE_TREE.
+    # In that case, the set of related permissions is empty.
     if obj_type is None:
         return set()
 

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -122,6 +122,9 @@ def build_permissions_set(object_uri, unbound_permission,
 
     obj_type = get_object_type(object_uri)
 
+    if obj_type is None:
+        return set()
+
     bound_permission = '%s:%s' % (obj_type, unbound_permission)
     granters = set()
 

--- a/kinto/tests/test_authorization.py
+++ b/kinto/tests/test_authorization.py
@@ -155,3 +155,7 @@ class PermissionInheritanceTest(unittest.TestCase):
                  (self.collection_uri, 'read'),
                  (self.record_uri, 'write'),
                  (self.record_uri, 'read')]))
+
+    def test_build_permissions_set_returns_empty_set_if_doesnt_know(self):
+        self.assertEquals(
+            build_permissions_set('/buckets', 'read'), set())

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -28,10 +28,16 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(self.record['id'], 'beers')
 
     def test_collection_endpoint_lists_them_all(self):
-        resp = self.app.get(self.collection_url, headers=self.headers)
+        resp = self.app.get(self.collection_url,
+                            headers=get_user_headers('alice'))
         records = resp.json['data']
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]['id'], 'beers')
+
+    def test_anyone_can_read_bucket_information(self):
+        resp = self.app.get(self.record_url, headers=get_user_headers('alice'))
+        record = resp.json['data']
+        self.assertEqual(record['id'], 'beers')
 
     def test_buckets_name_should_be_simple(self):
         self.app.put_json('/buckets/__beers__',

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -17,12 +17,6 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
                                  headers=self.headers)
         self.record = resp.json['data']
 
-    def get_app_settings(self, extra=None):
-        settings = super(BucketViewTest, self).get_app_settings(extra)
-        # Give the right to list buckets (for self.principal and alice).
-        settings['cliquet.bucket_read_principals'] = 'system.Authenticated'
-        return settings
-
     def test_buckets_are_global_to_every_users(self):
         self.app.get(self.record_url, headers=get_user_headers('alice'))
 


### PR DESCRIPTION
```
  File "~/mozilla/kinto/authorization.py", line 129, in build_permissions_set
    for obj, permission_list in inheritance_tree[bound_permission].items():
KeyError: 'None:read'
```