### PR TITLE
Default bucket UUID doesn't have dashes

### DIFF
--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -1,8 +1,10 @@
-import uuid
-from .support import (BaseWebTest, unittest, get_user_headers,
-                      MINIMALIST_RECORD)
+from six import text_type
+from uuid import UUID
 
 from cliquet.utils import hmac_digest
+
+from .support import (BaseWebTest, unittest, get_user_headers,
+                      MINIMALIST_RECORD)
 
 
 class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
@@ -17,7 +19,7 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         hmac_secret = settings['cliquet.userid_hmac_secret']
         bucket_id = hmac_digest(hmac_secret, self.principal)[:32]
 
-        self.assertEqual(result['data']['id'], bucket_id)
+        self.assertEqual(result['data']['id'], text_type(UUID(bucket_id)))
         self.assertEqual(result['permissions']['write'], [self.principal])
 
     def test_default_bucket_collections_are_automatically_created(self):
@@ -36,11 +38,12 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         self.assertEquals(resp.json['message'],
                           'Please authenticate yourself to use this endpoint.')
 
-    def test_bucket_id_is_an_uuid(self):
+    def test_bucket_id_is_an_uuid_with_dashes(self):
         bucket = self.app.get(self.bucket_url, headers=self.headers)
         bucket_id = bucket.json['data']['id']
+        self.assertIn('-', bucket_id)
         try:
-            uuid.UUID(bucket_id)
+            UUID(bucket_id)
         except ValueError:
             self.fail('bucket_id: %s is not a valid UUID.' % bucket_id)
 

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -1,3 +1,6 @@
+from six import text_type
+from uuid import UUID
+
 from pyramid.httpexceptions import HTTPForbidden, HTTPPreconditionFailed
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
@@ -57,7 +60,8 @@ def default_bucket(request):
     settings = request.registry.settings
     hmac_secret = settings['cliquet.userid_hmac_secret']
     # Build the user unguessable bucket_id UUID from its user_id
-    bucket_id = hmac_digest(hmac_secret, request.prefixed_userid)[:32]
+    digest = hmac_digest(hmac_secret, request.prefixed_userid)
+    bucket_id = text_type(UUID(digest[:32]))
     path = request.path.replace('default', bucket_id)
     querystring = request.url[(request.url.index(request.path) +
                                len(request.path)):]


### PR DESCRIPTION
I've seen that default record ID's have got dashes whereas default bucket id doesn't.

Does it makes sense to try to be consistent here?

```
$ http GET http://localhost:8888/v1/buckets/e93a0bb5b7d16d4f9bfd81b6d737271c -v --auth 'mary:marypassword'
{
    "data": {
        "id": "e93a0bb5b7d16d4f9bfd81b6d737271c", 
        "last_modified": 1436191171386
    }, 
    [...]
}
```
