### PR TITLE
by default kinto uses basic auth, not FxA

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,11 +37,11 @@ care of running and connecting to a PostgreSQL container:
 Authentication
 --------------
 
-By default, Kinto relies on Firefox Account OAuth2 Bearer tokens to authenticate
-users.
+By default, Kinto relies on BasicAuth to authenticate users. A unique
+user idenfier will be created for each couple of ``user:password`` so
+that you do not need to register a user to use it.
 
-See `cliquet documentation <http://cliquet.readthedocs.org/en/latest/reference/configuration.html#authentication>`_
-to configure authentication options.
+Kinto is compatible with Firefox Account.  See `cliquet documentation <http://cliquet.readthedocs.org/en/latest/reference/configuration.html#authentication>`_ to configure authentication options.
 
 
 Run in production


### PR DESCRIPTION
According to http://kinto.readthedocs.org/en/latest/installation.html#authentication, by default kinto uses Firefox Accounts for auth, but from what I've seen in the tutorial, it's using basic auth by default.

Am I missing something, or should the documentation be changed accordingly?