### PR TITLE
Getting a 401 on OPTIONS seems wrong

### DIFF
--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -60,7 +60,10 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
                      headers=self.headers,
                      status=400)
 
-    def test_option_is_possible_with_authentication_for_default(self):
+    def test_option_is_possible_without_authentication_for_default(self):
+        headers = 'authorization,content-type'
         self.app.options(self.collection_url + '/records',
-                         headers={'Origin': 'http://testserver',
-                                  'Access-Control-Request-Method': 'GET'})
+                         headers={
+                             'Origin': 'http://localhost:8000',
+                             'Access-Control-Request-Method': 'GET',
+                             'Access-Control-Request-Headers': headers})

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -59,3 +59,8 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         self.app.get(self.collection_url + '/records?_since=invalid',
                      headers=self.headers,
                      status=400)
+
+    def test_option_is_possible_with_authentication_for_default(self):
+        self.app.options(self.collection_url + '/records',
+                         headers={'Origin': 'http://testserver',
+                                  'Access-Control-Request-Method': 'GET'})

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -54,6 +54,14 @@ def create_collection(request, bucket_id):
 
 @view_config(route_name='default_bucket', permission=NO_PERMISSION_REQUIRED)
 def default_bucket(request):
+    if request.method.lower() == 'options':
+        path = request.path.replace('default', 'unknown')
+        subrequest = build_request(request, {
+            'method': 'OPTIONS',
+            'path': path
+        })
+        return request.invoke_subrequest(subrequest)
+
     if getattr(request, 'prefixed_userid', None) is None:
         raise HTTPForbidden  # Pass through the forbidden_view_config
 


### PR DESCRIPTION
![screen shot 2015-07-08 at 12 04 30](https://cloud.githubusercontent.com/assets/41547/8567960/f09c972e-2569-11e5-8e5e-2536745597f3.png)

@Natim says the patch should be:

```diff
 def default_bucket(request):
-    if getattr(request, 'prefixed_userid', None) is None:
+    if getattr(request, 'prefixed_userid', None) is None \
+       and request.method != 'OPTION':
```