### PR TITLE
bucket_id starting with default may use the wrong route.

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -41,7 +41,9 @@ def main(global_config, **settings):
         kwargs['ignore'] = 'kinto.views.flush'
 
     # Redirect default to the right endpoint
-    config.add_route('default_bucket', '/buckets/default{subpath:.*}')
+    config.add_route('default_bucket_collection',
+                     '/buckets/default/{subpath:.*}')
+    config.add_route('default_bucket', '/buckets/default')
 
     config.scan("kinto.views", **kwargs)
     return config.make_wsgi_app()

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -81,3 +81,22 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get(self.collection_url + '/records',
                             headers=headers, status=304)
         self.assertIn('Access-Control-Allow-Origin', resp.headers)
+
+    def test_bucket_id_starting_with_default_can_still_be_created(self):
+        # We need to create the bucket first since it is not the default bucket
+        resp = self.app.put_json(
+            self.bucket_url.replace('default', 'default-1234'),
+            {"data": {}}, headers=self.headers, status=201)
+        bucket_id = resp.json['data']['id']
+        self.assertEquals(bucket_id, 'default-1234')
+
+        # We can then create the collection
+        collection_url = '/buckets/default-1234/collections/default'
+        self.app.put_json(
+            collection_url,
+            {"data": {}},
+            headers=self.headers,
+            status=201)
+        resp = self.app.get('/buckets/default-1234/collections',
+                            headers=self.headers)
+        self.assertEquals(resp.json['data'][0]['id'], 'default')

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -20,7 +20,8 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
 
     def test_buckets_are_global_to_every_users(self):
         self.app.patch_json(self.record_url,
-                            {'permissions': {'read': [Authenticated]}},
+                            {'data': {},
+                             'permissions': {'read': [Authenticated]}},
                             headers=self.headers)
         self.app.get(self.record_url, headers=get_user_headers('alice'))
 

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -33,9 +33,9 @@ def create_bucket(request, bucket_id):
 
 
 def create_collection(request, bucket_id):
-    subpath = request.matchdict['subpath']
-    if subpath.startswith('/collections/'):
-        collection_id = subpath.split('/')[2]
+    subpath = request.matchdict.get('subpath')
+    if subpath and subpath.startswith('collections/'):
+        collection_id = subpath.split('/')[1]
         collection_put = (request.method.lower() == 'put' and
                           request.path.endswith(collection_id))
         if not collection_put:
@@ -54,6 +54,8 @@ def create_collection(request, bucket_id):
 
 
 @view_config(route_name='default_bucket', permission=NO_PERMISSION_REQUIRED)
+@view_config(route_name='default_bucket_collection',
+             permission=NO_PERMISSION_REQUIRED)
 def default_bucket(request):
     if request.method.lower() == 'options':
         path = request.path.replace('default', 'unknown')
@@ -71,7 +73,7 @@ def default_bucket(request):
     # Build the user unguessable bucket_id UUID from its user_id
     digest = hmac_digest(hmac_secret, request.prefixed_userid)
     bucket_id = text_type(UUID(digest[:32]))
-    path = request.path.replace('default', bucket_id)
+    path = request.path.replace('/buckets/default', '/buckets/%s' % bucket_id)
     querystring = request.url[(request.url.index(request.path) +
                                len(request.path)):]
 


### PR DESCRIPTION
We should add a test to make sure we can still create bucket ids that starts with default.